### PR TITLE
Fix custom plugin node cannot get viewport texture

### DIFF
--- a/addons/composite-shading/CompositeShadingSprite.gd
+++ b/addons/composite-shading/CompositeShadingSprite.gd
@@ -3,7 +3,7 @@ extends Node2D
 
 # Node children
 onready var viewport: Viewport = $Viewport
-onready var merged_sprite: Sprite = $Sprite
+onready var shading_sprite: Sprite = $Sprite
 onready var viewport_sprites: Node2D = $Viewport/Sprites
 
 # Reference to the static helper plugin tools.
@@ -24,6 +24,9 @@ func _ready():
 	viewport.transparent_bg = true
 	viewport.render_target_v_flip = true
 	viewport.render_target_update_mode = Viewport.UPDATE_ALWAYS
+	
+	# Sprite could have a reference to teh previous viewport if not fully cleared
+	shading_sprite.texture = null
 
 # Only added and ran, when the plugin is enabled for the original node.
 func _process(_delta: float):
@@ -67,15 +70,19 @@ func modify_viewport_bounds(size: Vector2, offset: Vector2) -> void:
 
 # `create_merged_sprite` display the new merged sprite.
 func create_merged_sprite(offset: Vector2) -> void:
-	merged_sprite.texture = viewport.get_texture()
-	merged_sprite.position = offset
+	var new_texture: Texture = viewport.get_texture()
+	if !new_texture:
+		return
+	
+	shading_sprite.texture = new_texture
+	shading_sprite.position = offset
 
 # `modify_sprite_material` change the canvas item material for the display sprite.
 func modify_sprite_material(new_material: Material) -> void:
 	if !(new_material is Material):
 		return
 		
-	merged_sprite.material = new_material
+	shading_sprite.material = new_material
 
 # `modify_viewport_sprite_container` clear old and add new sprites to the viewport.
 func modify_viewport_sprite_container(new_sprites: Array) -> void:

--- a/demo/DemoScene.tscn
+++ b/demo/DemoScene.tscn
@@ -17,7 +17,7 @@ __meta__ = {
 material = ExtResource( 2 )
 texture = ExtResource( 1 )
 __meta__ = {
-"composite_shading": false
+"composite_shading": true
 }
 
 [node name="Icon2" type="Sprite" parent="Node2D/Icon"]


### PR DESCRIPTION
The plugin was throwing errors due to residual reference left between the custom plugin node sprite and viewport.

This commit ensures that the custom plugin node sprite clears any reference to the viewport on initialization.